### PR TITLE
Update hugo

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,11 +9,7 @@
 
 name: Publish Development Docker image
 
-on:
-  push:
-    branches-ignore:
-      - master
-      - main
+on: [pull_request]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -33,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: my-docker-hub-namespace/my-docker-hub-repository
+          images: blbecker/hugo-build
       
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker image
+
+on:
+  push:
+    branches-ignore:
+      - master
+      - main
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: my-docker-hub-namespace/my-docker-hub-repository
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,7 +7,7 @@
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
 
-name: Publish Docker image
+name: Publish Development Docker image
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: my-docker-hub-namespace/my-docker-hub-repository
+          images: blbecker/hugo-build
       
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Release Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: my-docker-hub-namespace/my-docker-hub-repository
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:latest
 
-LABEL "com.github.actions.name"="Hugo Build"
+ENV HUGO_VERSION="v0.111.3"
 
-LABEL maintainer="benjamin@bckr.me"
+LABEL "com.github.actions.name"="Hugo Build"
+LABEL org.opencontainers.image.authors=="github@mail.bckr.me"
 
 # Configure Go
 ENV GOROOT /usr/lib/go
@@ -11,11 +12,8 @@ ENV PATH /opt/go/bin:$PATH
 
 RUN apk add --no-cache git make musl-dev go g++ bash
 
-RUN mkdir -p /opt/hugo && cd /opt/hugo && \
-    git clone https://github.com/gohugoio/hugo.git && \
-    cd hugo && \
-    go install --tags extended && \
-    cd /root && rm -rf /opt/hugo
+RUN go install -tags extended github.com/gohugoio/hugo@${HUGO_VERSION} && \
+    hugo version
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 runs:
   using:         'docker'
-  image:         'docker://blbecker/hugo-build:1.0'
+  image:         'docker://blbecker/hugo-build:0.111.3'
 
 inputs:
   hugo_args:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-export GIT_BRANCH=$(echo ${GITHUB_REF} | cut -f 3- -d "/")
-export GIT_SHA=$(git rev-parse --verify HEAD --short)
-
-echo -e "GIT_BRANCH=${GIT_BRANCH}\nGIT_SHA=${GIT_SHA}"
-
 git submodule init && git submodule update --recursive
 
 hugo ${INPUT_HUGO_ARGS}


### PR DESCRIPTION
Update the hugo version to 0.111.3 (latest as of this writing). 

Adds pipelines to build and push containers now that Dockerhub has moved `build` into a paid tier.